### PR TITLE
ci: use lockfile-restored env for rsconnect manifest

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -50,14 +50,10 @@ jobs:
 
       - name: Install renv dependencies
         uses: r-lib/actions/setup-renv@v2
-      
-      - name: Install extra dependencies
-        run: Rscript -e 'renv::install(c("any::rsconnect"))'
 
       - name: Create manifest.json
         shell: Rscript {0}
         run: |
-          renv::snapshot(prompt = FALSE)
           rsconnect::writeManifest()
           
       - name: Publish Connect content


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow configuration. The step that installed the `any::rsconnect` package as an extra dependency has been removed, and the manifest creation step no longer calls `renv::snapshot()`. These changes simplify the deployment process and reduce unnecessary operations.