### PR TITLE
ci: force clean renv restore before writeManifest

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -54,6 +54,7 @@ jobs:
       - name: Create manifest.json
         shell: Rscript {0}
         run: |
+          renv::restore(prompt = FALSE, clean = TRUE)
           rsconnect::writeManifest()
           
       - name: Publish Connect content


### PR DESCRIPTION
This pull request updates the deployment workflow to improve the reproducibility and cleanliness of the R environment before generating the deployment manifest.

Deployment workflow improvements:

* [`.github/workflows/deployment.yaml`](diffhunk://#diff-259f2188de53828dcb003900d2a84cfd00a909870115a6e14ddc019e96255087R57): Added a step to run `renv::restore(prompt = FALSE, clean = TRUE)` before creating the `manifest.json`, ensuring that the R environment is restored to a clean state before deployment.