### PR TITLE
Update rsconnect installation to specific version

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -52,12 +52,11 @@ jobs:
         uses: r-lib/actions/setup-renv@v2
       
       - name: Install extra dependencies
-        run: Rscript -e 'renv::install(c("any::rsconnect"))'
+        run: Rscript -e 'renv::install("rsconnect@1.8.0")'
 
       - name: Create manifest.json
         shell: Rscript {0}
         run: |
-          renv::snapshot(prompt = FALSE)
           rsconnect::writeManifest()
           
       - name: Publish Connect content


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow by specifying an exact version of the `rsconnect` package and removing an unnecessary `renv::snapshot` step.

- Dependency management:
  * Updated the installation command to use `rsconnect@1.8.0` instead of a generic installation, ensuring a specific version is used.

- Workflow simplification:
  * Removed the `renv::snapshot(prompt = FALSE)` command before creating the manifest, streamlining the deployment process.